### PR TITLE
Use HTTPS instead of SSH for pulling terraform modules in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ graph TB
             A_NLB["⚖️ Network LB<br/>(AWS Managed)"]
             A_S3["🗄️ S3 Storage<br/>Key Materials"]
             A_PROVIDER["🌉 VPC Endpoint Service<br/>(Expose to Bob)"]
-            A_CONSUMER["🔌 VPC Interface Endpoint<br/>(Connect to Bob)"]
+            A_CONSUMER["🔌 VPC Endpoint Interface<br/>(Connect to Bob)"]
             
             A_K8S_SVC --> A_NLB
             A_NLB --> A_PROVIDER
@@ -79,7 +79,7 @@ graph TB
             B_NLB["⚖️ Network LB<br/>(AWS Managed)"]
             B_S3["🗄️ S3 Storage<br/>Key Materials"]
             B_PROVIDER["🌉 VPC Endpoint Service<br/>(Expose to Alice)"]
-            B_CONSUMER["🔌 VPC Interface Endpoint<br/>(Connect to Alice)"]
+            B_CONSUMER["🔌 VPC Endpoint Interface<br/>(Connect to Alice)"]
             
             B_K8S_SVC --> B_NLB
             B_NLB --> B_PROVIDER

--- a/examples/mpc-network-consumer/main.tf
+++ b/examples/mpc-network-consumer/main.tf
@@ -2,7 +2,7 @@
 # This example demonstrates how to connect to existing MPC services from partners
 
 module "vpc_endpoint_consumer" {
-  source = "git::git@github.com:zama-ai/terraform-mpc-modules.git//modules/vpc-endpoint-consumer?ref=v0.1.3"
+  source = "git::https://github.com/zama-ai/terraform-mpc-modules.git//modules/vpc-endpoint-consumer?ref=v0.1.3"
 
   # Network environment configuration
   network_environment      = var.network_environment

--- a/examples/mpc-network-provider/main.tf
+++ b/examples/mpc-network-provider/main.tf
@@ -4,7 +4,7 @@ data "aws_region" "current" {}
 
 # Deploy VPC endpoints for the created NLBs (optional, only in provider mode)
 module "vpc_endpoint_provider" {
-  source = "git::git@github.com:zama-ai/terraform-mpc-modules.git//modules/vpc-endpoint-provider?ref=v0.1.3"
+  source = "git::https://github.com/zama-ai/terraform-mpc-modules.git//modules/vpc-endpoint-provider?ref=v0.1.3"
 
   # Network environment configuration
   network_environment      = var.network_environment

--- a/examples/mpc-party/main.tf
+++ b/examples/mpc-party/main.tf
@@ -4,7 +4,7 @@
 
 # Deploy MPC Party infrastructure using the enhanced mpc-party module
 module "mpc_party" {
-  source = "git::git@github.com:zama-ai/terraform-mpc-modules.git//modules/mpc-party?ref=v0.1.3"
+  source = "git::https://github.com/zama-ai/terraform-mpc-modules.git//modules/mpc-party?ref=v0.1.3"
 
   # Network environment configuration
   network_environment      = var.network_environment

--- a/examples/terragrunt-infra/kms-dev-v1/mpc-network-provider/terragrunt.hcl
+++ b/examples/terragrunt-infra/kms-dev-v1/mpc-network-provider/terragrunt.hcl
@@ -13,7 +13,7 @@ include "common" {
 
 # Reference the mpc-network-provider example module
 terraform {
-  source = "git::git@github.com:zama-ai/terraform-mpc-modules.git//modules/vpc-endpoint-provider?ref=v0.1.3"
+  source = "git::https://github.com/zama-ai/terraform-mpc-modules.git//modules/vpc-endpoint-provider?ref=v0.1.3"
   
   extra_arguments "tfvars" {
     commands = get_terraform_commands_that_need_vars()

--- a/examples/terragrunt-infra/kms-dev-v1/mpc-party/terragrunt.hcl
+++ b/examples/terragrunt-infra/kms-dev-v1/mpc-party/terragrunt.hcl
@@ -13,7 +13,7 @@ include "common" {
 
 # Reference the mpc-network-provider example module
 terraform {
-  source = "git::git@github.com:zama-ai/terraform-mpc-modules.git//modules/mpc-party?ref=v0.1.3"
+  source = "git::https://github.com/zama-ai/terraform-mpc-modules.git//modules/mpc-party?ref=v0.1.3"
   
   extra_arguments "tfvars" {
     commands = get_terraform_commands_that_need_vars()

--- a/examples/terragrunt-infra/zws-dev/mpc-network-consumer/terragrunt.hcl
+++ b/examples/terragrunt-infra/zws-dev/mpc-network-consumer/terragrunt.hcl
@@ -13,7 +13,7 @@ include "common" {
 
 # Reference the vpc-endpoint-consumer module
 terraform {
-  source = "git::git@github.com:zama-ai/terraform-mpc-modules.git//modules/vpc-endpoint-consumer?ref=v0.1.3"
+  source = "git::https://github.com/zama-ai/terraform-mpc-modules.git//modules/vpc-endpoint-consumer?ref=v0.1.3"
   
   extra_arguments "tfvars" {
     commands = get_terraform_commands_that_need_vars()

--- a/examples/terragrunt-infra/zws-dev/mpc-party/terragrunt.hcl
+++ b/examples/terragrunt-infra/zws-dev/mpc-party/terragrunt.hcl
@@ -13,7 +13,7 @@ include "common" {
 
 # Reference the mpc-network-provider example module
 terraform {
-  source = "git::git@github.com:zama-ai/terraform-mpc-modules.git//modules/mpc-party?ref=v0.1.3"
+  source = "git::https://github.com/zama-ai/terraform-mpc-modules.git//modules/mpc-party?ref=v0.1.3"
   
   extra_arguments "tfvars" {
     commands = get_terraform_commands_that_need_vars()


### PR DESCRIPTION
In examples, use https instead of ssh to pull terraform modules from github.

Useful if you have this error:
```
│ Could not download module "mpc_party" (main.tf:6) source code from "git::ssh://git@github.com/zama-ai/terraform-mpc-modules.git?ref=v0.1.3": error downloading 'ssh://git@github.com/zama-ai/terraform-mpc-modules.git?ref=v0.1.3':
│ /usr/bin/git exited with 128: Cloning into '.terraform/modules/mpc_party'...
│ git@github.com: Permission denied (publickey).
│ fatal: Could not read from remote repository.
```