### PR TITLE
Suggested NLB tags created by the loadbalancer service

### DIFF
--- a/modules/vpc-endpoint-provider/main.tf
+++ b/modules/vpc-endpoint-provider/main.tf
@@ -39,7 +39,10 @@ resource "kubernetes_service" "mpc_nlb" {
       "service.beta.kubernetes.io/aws-load-balancer-backend-protocol"                  = "tcp"
       "service.beta.kubernetes.io/aws-load-balancer-internal"                          = "true"
       "service.beta.kubernetes.io/aws-load-balancer-nlb-target-type"                   = "ip"
-      "service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags"          = "mpc-node=node-${var.party_id},environment=${var.network_environment}"
+      "service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags"          = join(",", concat([
+        "mpc-node=node-${var.party_id}",
+        "environment=${var.network_environment}"
+      ], [for k, v in var.tags : "${k}=${v}"]))
     }
 
     labels = merge({


### PR DESCRIPTION
I fixed that variable common_tags can be set in NLB created by service loadbalancer.