### PR TITLE
chore(mpc-party): rename configmap to mpc-party as suffix is unnecessary

### DIFF
--- a/examples/mpc-party/terraform.tfvars.example
+++ b/examples/mpc-party/terraform.tfvars.example
@@ -11,7 +11,7 @@ environment = "dev"
 
 # S3 Bucket Configuration
 bucket_prefix   = "zama-kms-decentralized-threshold-2"
-config_map_name = "mpc-party-2"
+config_map_name = "mpc-party"
 
 # Kubernetes Configuration
 cluster_name         = "zws-dev"

--- a/examples/terragrunt-infra/kms-dev-v1/mpc-party/terraform.tfvars
+++ b/examples/terragrunt-infra/kms-dev-v1/mpc-party/terraform.tfvars
@@ -8,7 +8,7 @@ party_name = "mpc-party-4"
 
 # S3 Bucket Configuration
 bucket_prefix   = "zama-kms-decentralized-threshold-4"
-config_map_name = "mpc-party-4"
+config_map_name = "mpc-party"
 
 # Kubernetes Configuration
 cluster_name             = "zws-dev"

--- a/examples/terragrunt-infra/zws-dev/mpc-party/terraform.tfvars
+++ b/examples/terragrunt-infra/zws-dev/mpc-party/terraform.tfvars
@@ -8,7 +8,7 @@ party_name = "mpc-party-2"
 
 # S3 Bucket Configuration
 bucket_prefix   = "zama-kms-decentralized-threshold-2"
-config_map_name = "mpc-party-2"
+config_map_name = "mpc-party"
 
 # Kubernetes Configuration
 cluster_name             = "zws-dev"


### PR DESCRIPTION
When running only one MPC party in a given namespace, it is unnecessary to use an index in the configmap name.
By standardizing on `mpc-party`, it allows all operators to reference the same configmap in their configuration.