### PR TITLE
feat(mpc-network): add partner_name to variable and remove owner update example

### DIFF
--- a/examples/mpc-network-provider/main.tf
+++ b/examples/mpc-network-provider/main.tf
@@ -11,7 +11,8 @@ module "vpc_endpoint_provider" {
   enable_region_validation = var.enable_region_validation
 
   # Party Configuration
-  party_id = var.party_id
+  party_id     = var.party_id
+  partner_name = var.partner_name
 
   namespace        = var.namespace
   create_namespace = false

--- a/examples/mpc-network-provider/terraform.tfvars.example
+++ b/examples/mpc-network-provider/terraform.tfvars.example
@@ -8,10 +8,10 @@ enable_region_validation = false
 cluster_name = "kms-development-v1"
 namespace    = "kms-decentralized"
 environment  = "dev"
-owner        = "zws-team"
 
 # Party Configuration
 party_id = "1"
+partner_name = "zws-team"
 
 # Kubernetes Provider Configuration
 # Option 1: Using kubeconfig context (current method)

--- a/examples/mpc-network-provider/variables.tf
+++ b/examples/mpc-network-provider/variables.tf
@@ -16,6 +16,11 @@ variable "party_id" {
   type        = string
 }
 
+variable "partner_name" {
+  description = "Partner name for the MPC service"
+  type        = string
+}
+
 variable "enable_region_validation" {
   type        = bool
   description = "Whether to enable region validation"
@@ -80,11 +85,6 @@ variable "environment" {
   default     = "zws-dev"
 }
 
-variable "owner" {
-  description = "Owner of the resources for tagging purposes"
-  type        = string
-  default     = "zws-team"
-}
 
 # VPC Endpoint Services Configuration
 variable "allowed_vpc_endpoint_principals" {


### PR DESCRIPTION
In example/mpc-network-provider, the variable owner was no longer used but remained, so it was removed. In module vpc-endpoint-provider, partner_name is required but was absent in example, so it was added.