### PR TITLE
mpc-party config ajustments

### DIFF
--- a/examples/mpc-party/main.tf
+++ b/examples/mpc-party/main.tf
@@ -11,6 +11,7 @@ module "mpc_party" {
   enable_region_validation = var.enable_region_validation
 
   # Party configuration
+  party_id     = var.party_id
   party_name    = var.party_name
   bucket_prefix = var.bucket_prefix
 

--- a/examples/mpc-party/variables.tf
+++ b/examples/mpc-party/variables.tf
@@ -40,7 +40,7 @@ variable "party_name" {
 }
 
 variable "config_map_name" {
-  description = "Name of the ConfigMap (defaults to 'mpc-party-config-{party_name}' if not provided)"
+  description = "Name of the ConfigMap"
   type        = string
   default     = null
 }

--- a/examples/mpc-party/variables.tf
+++ b/examples/mpc-party/variables.tf
@@ -29,6 +29,11 @@ variable "enable_region_validation" {
 }
 
 # MPC Party Configuration
+variable "party_id" {
+  description = "Party ID for the MPC service"
+  type        = number
+}
+
 variable "party_name" {
   description = "Name of the MPC party (used for tagging and resource naming)"
   type        = string

--- a/modules/mpc-party/main.tf
+++ b/modules/mpc-party/main.tf
@@ -425,6 +425,7 @@ resource "kubernetes_config_map" "mpc_party_config" {
 
   data = {
     "CORE_CLIENT__S3_ENDPOINT"                                  = "https://${aws_s3_bucket.vault_public_bucket.id}.s3.${aws_s3_bucket.vault_public_bucket.region}.amazonaws.com"
+    "KMS_CORE__THRESHOLD__MY_ID"                                = var.party_id
     "KMS_CORE__PRIVATE_VAULT__STORAGE__S3__BUCKET"              = aws_s3_bucket.vault_private_bucket.id
     "KMS_CORE__PRIVATE_VAULT__STORAGE__S3__PREFIX"              = ""
     "KMS_CORE__PUBLIC_VAULT__STORAGE__S3__BUCKET"               = aws_s3_bucket.vault_public_bucket.id

--- a/modules/mpc-party/main.tf
+++ b/modules/mpc-party/main.tf
@@ -406,7 +406,7 @@ resource "kubernetes_config_map" "mpc_party_config" {
   count = var.create_config_map ? 1 : 0
 
   metadata {
-    name      = var.config_map_name != null ? var.config_map_name : "mpc-party-config-${var.party_name}"
+    name      = var.config_map_name
     namespace = var.k8s_namespace
 
     labels = {

--- a/modules/mpc-party/variables.tf
+++ b/modules/mpc-party/variables.tf
@@ -189,7 +189,7 @@ variable "nodegroup_min_size" {
 variable "nodegroup_max_size" {
   type        = number
   description = "Maximum number of instances in the node group"
-  default     = 10
+  default     = 2
 }
 
 variable "nodegroup_desired_size" {
@@ -329,7 +329,7 @@ variable "nodegroup_update_config" {
     max_unavailable            = optional(number)
     max_unavailable_percentage = optional(number)
   })
-  description = "Update config for the node group"
+  description = "Update config for the node group (use either max_unavailable or max_unavailable_percentage as they are mutually exclusive)"
   default = {
     max_unavailable            = 1
     max_unavailable_percentage = null

--- a/modules/mpc-party/variables.tf
+++ b/modules/mpc-party/variables.tf
@@ -114,8 +114,8 @@ variable "create_config_map" {
 
 variable "config_map_name" {
   type        = string
-  description = "Name of the ConfigMap (defaults to 'mpc-party-config-{party_name}' if not provided)"
-  default     = null
+  description = "Name of the ConfigMap"
+  default     = "mpc-party"
 }
 
 variable "additional_config_data" {

--- a/modules/mpc-party/variables.tf
+++ b/modules/mpc-party/variables.tf
@@ -34,6 +34,11 @@ variable "bucket_prefix" {
 
 
 # MPC Party Configuration
+variable "party_id" {
+  description = "Party ID for the MPC service"
+  type        = string
+}
+
 variable "party_name" {
   type        = string
   description = "The name of the MPC party (used for resource naming and tagging)"

--- a/modules/mpc-party/variables.tf
+++ b/modules/mpc-party/variables.tf
@@ -560,10 +560,15 @@ variable "rds_parameter_group_family" {
   description = "DB parameter group family (e.g., postgres16). If null, no parameter group will be created."
 }
 
+
 variable "rds_parameters" {
   description = "List of DB parameter maps for the parameter group."
   type        = list(map(string))
-  default     = []
+  # Required by KMS-Connector which currently lacks ssl certificates
+  default     = [{
+    name  = "rds.force_ssl"
+    value = "0"
+  }]
 }
 
 # Snapshots / restore


### PR DESCRIPTION
Changes:
* enclave node group default size
* kms-connector required rds parameter
* configmap default name
* (breaking) add party ID to configmap so that it can later be ommited from helm chart values