### PR TITLE
fix(mpc-party): correctly handle custom RDS instance port

### DIFF
--- a/modules/mpc-party/main.tf
+++ b/modules/mpc-party/main.tf
@@ -816,7 +816,8 @@ module "rds_security_group" {
   vpc_id      = var.rds_vpc_id == null ? data.aws_eks_cluster.cluster.vpc_config[0].vpc_id : var.rds_vpc_id
   ingress_with_cidr_blocks = [
     {
-      rule        = "postgresql-tcp"
+      from_port   = var.rds_port
+      to_port     = var.rds_port
       cidr_blocks = join(",", concat(var.rds_allowed_cidr_blocks, local.private_subnet_cidr_blocks))
     }
   ]


### PR DESCRIPTION
The RDS security group uses the default postgresql port, even if we set a custom port on the instance