### PR TITLE
fix(vpc-endpoint-consumer): aws_vpc_endpoint.party_interface_endpoint

### DIFF
--- a/modules/vpc-endpoint-consumer/main.tf
+++ b/modules/vpc-endpoint-consumer/main.tf
@@ -51,7 +51,7 @@ resource "aws_vpc_endpoint" "party_interface_endpoints" {
   vpc_endpoint_type = "Interface"
   subnet_ids = length(coalesce(each.value.availability_zones, [])) > 0 && var.cluster_name != null ? [
     for subnet_id, subnet in data.aws_subnet.cluster_subnets : subnet_id
-    if subnet.map_public_ip_on_launch == false && contains(each.value.availability_zones, subnet.availability_zone_id)
+    if subnet.map_public_ip_on_launch == false && contains(each.value.availability_zones, subnet.availability_zone)
   ] : local.subnet_ids
   security_group_ids = local.security_group_ids
   service_region     = each.value.region


### PR DESCRIPTION
The format of `availability_zones` and `availability_zone_id` is irregular causing `subnet_ids` to become an empty list which has cascading issues with `aws_vpc_endpoint.party_interface_endpoints[each.key].dns_entry[0].dns_name` usage.

For example:

```
each.value.availability_zones =  [ "eu-west-1b", "eu-west-1c", "eu-west-1a"]
subnet.availability_zone_id = "euw1-az2"
``` 