### PR TITLE
fix: Add role name variable and prevent destroy

### DIFF
--- a/modules/mpc-backup-vault/README.md
+++ b/modules/mpc-backup-vault/README.md
@@ -85,6 +85,8 @@ No modules.
 | <a name="input_bucket_cross_account_id"></a> [bucket\_cross\_account\_id](#input\_bucket\_cross\_account\_id) | ID of the AWS account that can access the backup bucket. | `string` | n/a | yes |
 | <a name="input_bucket_prefix"></a> [bucket\_prefix](#input\_bucket\_prefix) | The prefix for the S3 bucket names | `string` | `"mpc-backup-vault"` | no |
 | <a name="input_enable_replication"></a> [enable\_replication](#input\_enable\_replication) | Enable cross-region replication for the backup bucket. | `bool` | `false` | no |
+| <a name="input_mpc_backup_replication_role_name"></a> [mpc\_backup\_replication\_role\_name](#input\_mpc\_backup\_replication\_role\_name) | The name of the MPC backup replication role. | `string` | `null` | no |
+| <a name="input_mpc_backup_role_name"></a> [mpc\_backup\_role\_name](#input\_mpc\_backup\_role\_name) | The name of the MPC backup role. | `string` | `null` | no |
 | <a name="input_party_name"></a> [party\_name](#input\_party\_name) | The name of the MPC party (used for resource naming and tagging) | `string` | n/a | yes |
 | <a name="input_replica_bucket_prefix"></a> [replica\_bucket\_prefix](#input\_replica\_bucket\_prefix) | The prefix for the replica S3 bucket name. | `string` | `"mpc-backup-vault-replica"` | no |
 | <a name="input_replica_region"></a> [replica\_region](#input\_replica\_region) | AWS region for the replica bucket. Required when enable\_replication is true. | `string` | `null` | no |

--- a/modules/mpc-backup-vault/main.tf
+++ b/modules/mpc-backup-vault/main.tf
@@ -74,6 +74,60 @@ resource "aws_s3_bucket_policy" "backup_bucket" {
 }
 
 # ***************************************
+#  IAM Role & Policy for MPC Backup Vault
+# ***************************************
+
+# Trust policy: Allow trusted principals to assume this role
+data "aws_iam_policy_document" "assume_role" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    effect  = "Allow"
+    principals {
+      type        = "AWS"
+      identifiers = var.trusted_principal_arns
+    }
+  }
+}
+
+resource "aws_iam_role" "mpc_backup_role" {
+  name               = var.mpc_backup_role_name != null ? var.mpc_backup_role_name : "mpc-backup-${var.party_name}"
+  assume_role_policy = data.aws_iam_policy_document.assume_role.json
+  tags               = var.tags
+}
+
+# Policy allowing access to the bucket
+resource "aws_iam_policy" "mpc_aws" {
+  name = var.mpc_backup_role_name != null ? var.mpc_backup_role_name : "mpc-backup-${var.party_name}"
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AllowObjectActions"
+        Effect = "Allow"
+        Action = "s3:*Object"
+        Resource = [
+          "arn:aws:s3:::${aws_s3_bucket.backup_bucket.id}/*"
+        ]
+      },
+      {
+        Sid    = "AllowListBucket"
+        Effect = "Allow"
+        Action = "s3:ListBucket"
+        Resource = [
+          "arn:aws:s3:::${aws_s3_bucket.backup_bucket.id}"
+        ]
+      }
+    ]
+  })
+}
+
+# Attach policy to the role
+resource "aws_iam_role_policy_attachment" "mpc_backup_attach" {
+  role       = aws_iam_role.mpc_backup_role.name
+  policy_arn = aws_iam_policy.mpc_aws.arn
+}
+
+# ***************************************
 #  S3 Replica Bucket (Cross-Region)
 # ***************************************
 resource "aws_s3_bucket" "replica_bucket" {
@@ -205,58 +259,4 @@ resource "aws_s3_bucket_replication_configuration" "backup_bucket" {
     aws_s3_bucket_versioning.backup_bucket,
     aws_s3_bucket_versioning.replica_bucket
   ]
-}
-
-# ***************************************
-#  IAM Role & Policy for MPC Backup Vault
-# ***************************************
-
-# Trust policy: Allow trusted principals to assume this role
-data "aws_iam_policy_document" "assume_role" {
-  statement {
-    actions = ["sts:AssumeRole"]
-    effect  = "Allow"
-    principals {
-      type        = "AWS"
-      identifiers = var.trusted_principal_arns
-    }
-  }
-}
-
-resource "aws_iam_role" "mpc_backup_role" {
-  name               = var.mpc_backup_role_name != null ? var.mpc_backup_role_name : "mpc-backup-${var.party_name}"
-  assume_role_policy = data.aws_iam_policy_document.assume_role.json
-  tags               = var.tags
-}
-
-# Policy allowing access to the bucket
-resource "aws_iam_policy" "mpc_aws" {
-  name = var.mpc_backup_role_name != null ? var.mpc_backup_role_name : "mpc-backup-${var.party_name}"
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Sid    = "AllowObjectActions"
-        Effect = "Allow"
-        Action = "s3:*Object"
-        Resource = [
-          "arn:aws:s3:::${aws_s3_bucket.backup_bucket.id}/*"
-        ]
-      },
-      {
-        Sid    = "AllowListBucket"
-        Effect = "Allow"
-        Action = "s3:ListBucket"
-        Resource = [
-          "arn:aws:s3:::${aws_s3_bucket.backup_bucket.id}"
-        ]
-      }
-    ]
-  })
-}
-
-# Attach policy to the role
-resource "aws_iam_role_policy_attachment" "mpc_backup_attach" {
-  role       = aws_iam_role.mpc_backup_role.name
-  policy_arn = aws_iam_policy.mpc_aws.arn
 }

--- a/modules/mpc-backup-vault/main.tf
+++ b/modules/mpc-backup-vault/main.tf
@@ -18,8 +18,10 @@ locals {
 #  S3 Buckets for Vault Private Storage
 # ***************************************
 resource "aws_s3_bucket" "backup_bucket" {
-  force_destroy = true
-  bucket        = local.backup_bucket_name
+  bucket = local.backup_bucket_name
+  lifecycle {
+    prevent_destroy = true
+  }
   tags = merge(var.tags, {
     "Name"    = local.backup_bucket_name
     "Type"    = "backup-vault"
@@ -75,12 +77,12 @@ resource "aws_s3_bucket_policy" "backup_bucket" {
 #  S3 Replica Bucket (Cross-Region)
 # ***************************************
 resource "aws_s3_bucket" "replica_bucket" {
-  count         = var.enable_replication ? 1 : 0
-  provider      = aws.replica
-  force_destroy = true
-  bucket        = local.replica_bucket_name
+  count    = var.enable_replication ? 1 : 0
+  provider = aws.replica
+  bucket   = local.replica_bucket_name
 
   lifecycle {
+    prevent_destroy = true
     precondition {
       condition     = var.replica_region != null
       error_message = "replica_region must be set when enable_replication is true."
@@ -131,14 +133,14 @@ data "aws_iam_policy_document" "replication_assume_role" {
 
 resource "aws_iam_role" "replication_role" {
   count              = var.enable_replication ? 1 : 0
-  name               = "mpc-backup-replication-${var.party_name}"
+  name               = var.mpc_backup_replication_role_name != null ? var.mpc_backup_replication_role_name : "mpc-backup-replication-${var.party_name}"
   assume_role_policy = data.aws_iam_policy_document.replication_assume_role[0].json
   tags               = var.tags
 }
 
 resource "aws_iam_policy" "replication_policy" {
   count = var.enable_replication ? 1 : 0
-  name  = "mpc-backup-replication-${var.party_name}"
+  name  = var.mpc_backup_replication_role_name != null ? var.mpc_backup_replication_role_name : "mpc-backup-replication-${var.party_name}"
   policy = jsonencode({
     Version = "2012-10-17"
     Statement = [
@@ -222,14 +224,14 @@ data "aws_iam_policy_document" "assume_role" {
 }
 
 resource "aws_iam_role" "mpc_backup_role" {
-  name               = "mpc-backup-${var.party_name}"
+  name               = var.mpc_backup_role_name != null ? var.mpc_backup_role_name : "mpc-backup-${var.party_name}"
   assume_role_policy = data.aws_iam_policy_document.assume_role.json
   tags               = var.tags
 }
 
 # Policy allowing access to the bucket
 resource "aws_iam_policy" "mpc_aws" {
-  name = "mpc-backup-${var.party_name}"
+  name = var.mpc_backup_role_name != null ? var.mpc_backup_role_name : "mpc-backup-${var.party_name}"
   policy = jsonencode({
     Version = "2012-10-17"
     Statement = [

--- a/modules/mpc-backup-vault/variables.tf
+++ b/modules/mpc-backup-vault/variables.tf
@@ -54,3 +54,15 @@ variable "replica_bucket_prefix" {
   description = "The prefix for the replica S3 bucket name."
   default     = "mpc-backup-vault-replica"
 }
+
+variable "mpc_backup_role_name" {
+  type        = string
+  description = "The name of the MPC backup role."
+  default     = null
+}
+
+variable "mpc_backup_replication_role_name" {
+  type        = string
+  description = "The name of the MPC backup replication role."
+  default     = null
+}


### PR DESCRIPTION
Since the partners use the same AWS account for testnet and mainnet backup, we need to give the ability to change the role name to avoid conflict between role name